### PR TITLE
Solid state R1rho equations

### DIFF
--- a/ringnmr/src/main/java/org/comdnmr/modelfree/RelaxEquations.java
+++ b/ringnmr/src/main/java/org/comdnmr/modelfree/RelaxEquations.java
@@ -44,11 +44,12 @@ public class RelaxEquations {
     public final static double GAMMA_H = 2.6752218744e8;
     public final static double GAMMA_D = 4.1065e7;
 
-    public final static double PLANCK = 1.0546e-34;
+    public final static double HBAR = 1.054571817e-34;
+    public final static double R_HH = 3.0e-10; // Simon chucked this in in order for some tests to work.
     public final static double R_HN = 1.02e-10;
     public final static double R_HC = 1.09e-10;
     public final static double R_CC = 1.51e-10;
-    public final static double SIGMA = -172.0e-6;
+    public final static double SIGMA = -172.0e-6;  // N.B. this is for Δσ = (3/2)σ = σzz - (1/2) (σxx + σyy)
     public final static double QCC = Math.PI*167.0e3/2.0;
     public final static double QCC2 = QCC * QCC;
 
@@ -61,6 +62,7 @@ public class RelaxEquations {
         GAMMA_MAP.put("N", GAMMA_N);
         GAMMA_MAP.put("C", GAMMA_C);
         GAMMA_MAP.put("D", GAMMA_D);
+        R_MAP.put("HH", R_HH);  // Simon chucked this in in order for some tests to work.
         R_MAP.put("HN", R_HN);
         R_MAP.put("NH", R_HN);
         R_MAP.put("HC", R_HC);
@@ -74,8 +76,9 @@ public class RelaxEquations {
     private final double r;
     private final double d;
     private final double d2;
-    private final double c;
-    private final double c2;
+    private final double c;  // (ωΔσ) / √3
+    private final double c2;   // (ω²Δσ²) / 3
+
     private final double gammaS;
     private final double gammaI;
     private final double sf;
@@ -101,7 +104,7 @@ public class RelaxEquations {
             wS = wI * gammaS / gammaI;
         }
         r = R_MAP.get(elem1 + elem2);
-        d = MU0 * (gammaI * gammaS * PLANCK) / (4.0 * Math.PI * r * r * r);
+        d = -MU0 * (gammaI * gammaS * HBAR) / (4.0 * Math.PI * Math.pow(r, 3.0));
         d2 = d * d;
         c = wS * SIGMA_MAP.get(elem2) / Math.sqrt(3.0);
         c2 = c * c;
@@ -109,9 +112,7 @@ public class RelaxEquations {
             wValues = new double[]{0.0, wI, 2.0 * wI};
         } else {
             wValues = new double[]{0.0, wS, wI - wS, wI, wI + wS};
-
         }
-
         this.sf = sf;
     }
 
@@ -690,7 +691,7 @@ public class RelaxEquations {
 
         double ddN = 160.0e-6;
         double theta = 17.0 * Math.PI / 180.0;
-        double p = MU0 * gammaI * gammaS * PLANCK / (8.0 * Math.PI * SQRT2 * r * r * r);
+        double p = MU0 * gammaI * gammaS * HBAR / (8.0 * Math.PI * SQRT2 * r * r * r);
         double dN = gammaS * B0 * ddN / (3.0 * SQRT2);
 
         double cosTheta = Math.cos(theta);
@@ -778,30 +779,64 @@ public class RelaxEquations {
     // SOLID STATE STUFF
 
     /**
-     *
-     * @param wr double. Rotating frame (MAS) frequency (rad s-1).
-     * @param we double. Spin-lock field frequency (rad s-1).
-     * @param tau double. Rotational correlation time (s).
-     * @param S2 double. Order parameter.
-     * @return double. R1rhoCSA: Contribution from CSA to R1rho.
-     */
+    * Compute the CSA contribution to R1rho relaxation in the solid-state context.
+    * <p>
+    * Computes Eq. 39 in J. Phys. Chem. B 2017, 121, 25, 6117–6130.
+    *
+    * @param wr Rotating frame (MAS) frequency (rad s-1).
+    * @param we Spin-lock field frequency (rad s-1).
+    * @param tau Rotational correlation time (s).
+    * @param S2 Order parameter.
+    * @return R1rhoCSA: Contribution from CSA to R1rho.
+    */
     public double R1rhoCSA(double wr, double we, double tau, double S2) {
-        // Spectral density used here is Eq. 23 in
-        // R. Kurbanov, T. Zinkevich, A. Krushelnitsky, J. Chem. Phys. 135, 184104 (2011)
         // Using public double J(double w, double tau, double S2)
-        // To compute it, which requires S2 to be set to 1 - S2 to be valid.
         double oneMinusS2 = 1.0 - S2;
-        // Usually R1rho experiments are performed with the locking field on resonance,
+        // Usually, R1rho experiments are performed with the locking field on resonance,
         // such that theta_p is 90.
         // In general, arccos(2 * pi * offset / we) should be used.
         double theta_p = 0.5 * Math.PI;
-        double R1CSA = 2.25 * c2 * J(wS, tau, oneMinusS2);
-        double R1DeltaCSA = 0.5 * c2 * (
-            0.5 * J(we - 2 * wr, tau, oneMinusS2) +
-            J(we - wr, tau, oneMinusS2) +
-            J(we + wr, tau, oneMinusS2) +
-            0.5 * J(we + 2 * wr, tau, oneMinusS2)
+        // N.B. c2 is equivalent to (ω² Δσ²) / 3
+        return c2 * (
+            0.1111111111 * Math.pow(Math.sin(theta_p), 2.0) * (
+                J(we - 2 * wr, tau, oneMinusS2) +
+                2.0 * J(we - wr, tau, oneMinusS2) +
+                2.0 * J(we + wr, tau, oneMinusS2) +
+                J(we + 2 * wr, tau, oneMinusS2)
+            ) +
+            0.25 * (3.0 + Math.cos(2 * theta_p)) * J(wS, tau, oneMinusS2)
         );
-        return R1CSA + Math.pow(Math.sin(theta_p), 2.0) * (R1DeltaCSA - 0.5 * R1CSA);
+    }
+
+    /**
+     * Compute the heteronuclear dipolar contribution to R1rho relaxation in the
+     * solid-state context.
+     * <p>
+     * Computes Eq. 33 in J. Phys. Chem. B 2017, 121, 25, 6117–6130.
+     *
+     * @param wr Rotating frame (MAS) frequency (rad s-1).
+     * @param we Spin-lock field frequency (rad s-1).
+     * @param tau Rotational correlation time (s).
+     * @param S2 Order parameter.
+     * @return R1rhoDD: Contribution from dipolar interaction to R1rho.
+     */
+    public double R1rhoDDHetero(double wr, double we, double tau, double S2) {
+        // See applicable comments on omeMinusS2 and theta_p in R1rhoCSA
+        double oneMinusS2 = 1.0 - S2;
+        double theta_p = 0.5 * Math.PI;
+        return 0.25 * d2 * (
+            0.3333333333 * Math.pow(Math.sin(theta_p), 2.0) * (
+                J(we - 2 * wr, tau, oneMinusS2) +
+                2.0 * J(we - wr, tau, oneMinusS2) +
+                2.0 * J(we + wr, tau, oneMinusS2) +
+                J(we + 2 * wr, tau, oneMinusS2) +
+                9.0 * J(wS, tau, oneMinusS2)
+            ) +
+            0.25 * (3.0 + Math.cos(2 * theta_p)) * (
+                3.0 * J(wI, tau, oneMinusS2) +
+                6.0 * J(wI + wS, tau, oneMinusS2) +
+                J(wI - wS, tau, oneMinusS2)
+            )
+        );
     }
 }

--- a/ringnmr/src/main/java/org/comdnmr/modelfree/RelaxEquations.java
+++ b/ringnmr/src/main/java/org/comdnmr/modelfree/RelaxEquations.java
@@ -820,7 +820,7 @@ public class RelaxEquations {
      * @param S2 Order parameter.
      * @return R1rhoDD: Contribution from dipolar interaction to R1rho.
      */
-    public double R1rhoDDHetero(double wr, double we, double tau, double S2) {
+    public double R1rhoIS(double wr, double we, double tau, double S2) {
         // See applicable comments on omeMinusS2 and theta_p in R1rhoCSA
         double oneMinusS2 = 1.0 - S2;
         double theta_p = 0.5 * Math.PI;
@@ -837,6 +837,38 @@ public class RelaxEquations {
                 6.0 * J(wI + wS, tau, oneMinusS2) +
                 J(wI - wS, tau, oneMinusS2)
             )
+        );
+    }
+
+    public double R1rhoAA(double wr, double we, double tau, double S2) {
+        if (getGammaI() != getGammaS()) {
+            throw new RuntimeException("Expected the two nuclei to be the same.");
+        }
+        // See applicable comments on omeMinusS2 and theta_p in R1rhoCSA
+        double oneMinusS2 = 1.0 - S2;
+        double theta_p = 0.5 * Math.PI;
+        double sinSq2theta = Math.pow(Math.sin(2.0 * theta_p), 2.0);
+        double sinFourthTheta = Math.pow(Math.sin(theta_p), 4.0);
+        double threeCos2theta = 3.0 * Math.cos(2.0 * theta_p);
+        return 0.75 * d2 * (
+            0.125 * sinSq2theta * (
+                J(wr - we, tau, oneMinusS2) +
+                J(wr + we, tau, oneMinusS2)
+            ) +
+            0.5 * sinFourthTheta * (
+                J(wr - 2.0 * we, tau, oneMinusS2) +
+                J(wr + 2.0 * we, tau, oneMinusS2)
+            ) +
+            0.0625 * sinSq2theta * (
+                J(2.0 * wr - we, tau, oneMinusS2) +
+                J(2.0 * wr + we, tau, oneMinusS2)
+            ) +
+            0.25 * sinFourthTheta * (
+                J(2.0 * wr - 2.0 * we, tau, oneMinusS2) +
+                J(2.0 * wr + 2.0 * we, tau, oneMinusS2)
+            ) +
+            0.25 * (7.0 - threeCos2theta) * J(wI, tau, oneMinusS2) +
+            0.5 * (5.0 + threeCos2theta) * J(2.0 * wI, tau, oneMinusS2)
         );
     }
 }

--- a/ringnmr/src/test/java/org/comdnmr/modelfree/RelaxEquationsTest.java
+++ b/ringnmr/src/test/java/org/comdnmr/modelfree/RelaxEquationsTest.java
@@ -5,29 +5,54 @@ import org.junit.Test;
 
 public class RelaxEquationsTest {
     double twoPI = 2.0 * Math.PI;
-    double[] R1rhoTargets = {
-        367.95510639514123, 296.2386769001938, 227.1116787400174, 171.8855136375552, 131.6300869486979,
-        71.688811251761, 71.09001993233547, 70.37120833078939, 69.53968236184136, 68.60363518294635,
-        7.334645374625591, 7.333994404029964, 7.333198930185943, 7.332259047151564, 7.331174866020584
+    double[] R1rhoCSATargets = {
+        1.4148978688487408e-05, 7.221345551571136, 0.9586089899637809, 1.4148978688487293e-05,
+        7.164909988657386, 1.8616125433308737, 1.414897868848692e-05, 6.985250038220472,
+        193.56034510531762, 1.4148978688485414e-05, 6.292946892439036, 97.12185914367787
     };
-    double[] R1rhoTaus = {1.0e-5, 1.0e-6, 1.0e-7};
-    double[] R1rhoOmegaEs = {twoPI * 20.0e3, twoPI * 25.0e3, twoPI * 30.0e3, twoPI * 35.0e3, twoPI * 40.0e3};
-    double R1rhoOmegaR = twoPI * 10.0e3;
-    double R1rhoS2 = 0.3295;
-    double R1rhoSIGMA = -37.0e-6;
+    double[] R1rhoHNTargets = {
+            0.0005196600618600594, 92.82942378966885, 12.322656458970256, 0.000519660061860058,
+            92.1039606967329, 23.930510034543467, 0.0005196600618600531, 89.79448318660548,
+            2488.163136700531, 0.0005196600618600338, 80.89512335997507, 1248.4738588553196
+    };
+    double[] R1rhoTaus = {1.0e-12, 1.0e-6, 1.0e-4};
+    double[] R1rhoOmegaEs = {0.0, twoPI * 1.9e4, twoPI * 3.9e4, twoPI * 7.9e4};
+    double R1rhoOmegaR = twoPI * 4.0e4;
+    double R1rhoS2 = 0.9;
+    double R1rhoSigmaH = 8.0 * 1.0e-6;  // Δσ
+    double R1rhoWH = 6.0e8;
 
     @Test
     public void testR1rhoCSA() {
-        RelaxEquations.setSigma("C", R1rhoSIGMA);
-        RelaxEquations relax = new RelaxEquations(400.0e6, "H", "C");
+        RelaxEquations.setSigma("H", R1rhoSigmaH);
+        RelaxEquations relax = new RelaxEquations(R1rhoWH, "H", "H");
         int i = 0;
-        for (double R1rhoTau: R1rhoTaus) {
-            for (double R1rhoOmegaE: R1rhoOmegaEs) {
-               double R1rhoTarget = R1rhoTargets[i];
+        for (double R1rhoOmegaE: R1rhoOmegaEs) {
+            for (double R1rhoTau: R1rhoTaus) {
+                double target = R1rhoCSATargets[i];
                 Assert.assertEquals(
-                    R1rhoTarget,
+                    target,
                     relax.R1rhoCSA(
                        R1rhoOmegaR, R1rhoOmegaE, R1rhoTau, R1rhoS2
+                    ),
+                    1.0e-6
+                );
+                i++;
+            }
+        }
+    }
+
+    @Test
+    public void testR1rhoHN() {
+        RelaxEquations relax = new RelaxEquations(R1rhoWH, "H", "N");
+        int i = 0;
+        for (double R1rhoOmegaE: R1rhoOmegaEs) {
+            for (double R1rhoTau: R1rhoTaus) {
+                double target = R1rhoHNTargets[i];
+                Assert.assertEquals(
+                    target,
+                    relax.R1rhoDDHetero(
+                        R1rhoOmegaR, R1rhoOmegaE, R1rhoTau, R1rhoS2
                     ),
                     1.0e-6
                 );

--- a/ringnmr/src/test/java/org/comdnmr/modelfree/RelaxEquationsTest.java
+++ b/ringnmr/src/test/java/org/comdnmr/modelfree/RelaxEquationsTest.java
@@ -1,0 +1,38 @@
+package org.comdnmr.modelfree;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RelaxEquationsTest {
+    double twoPI = 2.0 * Math.PI;
+    double[] R1rhoTargets = {
+        367.95510639514123, 296.2386769001938, 227.1116787400174, 171.8855136375552, 131.6300869486979,
+        71.688811251761, 71.09001993233547, 70.37120833078939, 69.53968236184136, 68.60363518294635,
+        7.334645374625591, 7.333994404029964, 7.333198930185943, 7.332259047151564, 7.331174866020584
+    };
+    double[] R1rhoTaus = {1.0e-5, 1.0e-6, 1.0e-7};
+    double[] R1rhoOmegaEs = {twoPI * 20.0e3, twoPI * 25.0e3, twoPI * 30.0e3, twoPI * 35.0e3, twoPI * 40.0e3};
+    double R1rhoOmegaR = twoPI * 10.0e3;
+    double R1rhoS2 = 0.3295;
+    double R1rhoSIGMA = -37.0e-6;
+
+    @Test
+    public void testR1rhoCSA() {
+        RelaxEquations.setSigma("C", R1rhoSIGMA);
+        RelaxEquations relax = new RelaxEquations(400.0e6, "H", "C");
+        int i = 0;
+        for (double R1rhoTau: R1rhoTaus) {
+            for (double R1rhoOmegaE: R1rhoOmegaEs) {
+               double R1rhoTarget = R1rhoTargets[i];
+                Assert.assertEquals(
+                    R1rhoTarget,
+                    relax.R1rhoCSA(
+                       R1rhoOmegaR, R1rhoOmegaE, R1rhoTau, R1rhoS2
+                    ),
+                    1.0e-6
+                );
+                i++;
+            }
+        }
+    }
+}

--- a/ringnmr/src/test/java/org/comdnmr/modelfree/RelaxEquationsTest.java
+++ b/ringnmr/src/test/java/org/comdnmr/modelfree/RelaxEquationsTest.java
@@ -11,9 +11,14 @@ public class RelaxEquationsTest {
         193.56034510531762, 1.4148978688485414e-05, 6.292946892439036, 97.12185914367787
     };
     double[] R1rhoHNTargets = {
-            0.0005196600618600594, 92.82942378966885, 12.322656458970256, 0.000519660061860058,
-            92.1039606967329, 23.930510034543467, 0.0005196600618600531, 89.79448318660548,
-            2488.163136700531, 0.0005196600618600338, 80.89512335997507, 1248.4738588553196
+        0.0005196600618600594, 92.82942378966885, 12.322656458970256, 0.000519660061860058,
+        92.1039606967329, 23.930510034543467, 0.0005196600618600531, 89.79448318660548,
+        2488.163136700531, 0.0005196600618600338, 80.89512335997507, 1248.4738588553196
+    };
+    double[] R1rhoHHTargets = {
+        0.00011720530140576303, 31.405449205080966, 4.168965929005294, 0.00011720530140576101,
+        30.43014504038675, 455.87926068278733, 0.00011720530140575456, 27.462847707589887,
+        229.54734968483226, 0.00011720530140572838, 18.700020481571983, 0.5590040134704212,
     };
     double[] R1rhoTaus = {1.0e-12, 1.0e-6, 1.0e-4};
     double[] R1rhoOmegaEs = {0.0, twoPI * 1.9e4, twoPI * 3.9e4, twoPI * 7.9e4};
@@ -51,10 +56,30 @@ public class RelaxEquationsTest {
                 double target = R1rhoHNTargets[i];
                 Assert.assertEquals(
                     target,
-                    relax.R1rhoDDHetero(
+                    relax.R1rhoIS(
                         R1rhoOmegaR, R1rhoOmegaE, R1rhoTau, R1rhoS2
                     ),
                     1.0e-6
+                );
+                i++;
+            }
+        }
+    }
+
+    @Test
+    public void testR1rhoAA() {
+        RelaxEquations.setSigma("H", R1rhoSigmaH);
+        RelaxEquations relax = new RelaxEquations(R1rhoWH, "H", "H");
+        int i = 0;
+        for (double R1rhoOmegaE: R1rhoOmegaEs) {
+            for (double R1rhoTau: R1rhoTaus) {
+                double target = R1rhoHHTargets[i];
+                Assert.assertEquals(
+                        target,
+                        relax.R1rhoAA(
+                                R1rhoOmegaR, R1rhoOmegaE, R1rhoTau, R1rhoS2
+                        ),
+                        1.0e-6
                 );
                 i++;
             }


### PR DESCRIPTION
Included solid-state R1rho expressions for: CSA, heteronuclear DD, homonuclear DD.
See _J. Phys. Chem. B 2017, 121, 25, 6117–6130_ (Equations 39, 33, 28, respectively).

Should think about what to pass into these methods as arguments, and what should be held as class attributes. The methods are currently implemented to take `wr` (MAS frequency), `we` (spin-lock field strength), `tau` (correlation time for local motion), `S2` (order parameter for local motion).