### PR TITLE
Solid state: create new model free object

### DIFF
--- a/ringnmr/src/main/java/org/comdnmr/modelfree/models/MFModelIso1.java
+++ b/ringnmr/src/main/java/org/comdnmr/modelfree/models/MFModelIso1.java
@@ -50,14 +50,16 @@ public class MFModelIso1 extends MFModelIso {
         return getAllParNames("Sf2");
     }
 
+    public double spectralDensity(double s2, double omega, double tau) {
+        return 0.4 * s2 / sN * tau / (1.0 + Math.pow(omega * tau, 2.0));
+    }
     @Override
     public double[] calc(double[] omegas) {
         double tauMx = tauM * 1.0e-9;
         double[] J = new double[omegas.length];
         int j = 0;
         for (double omega : omegas) {
-            double omega2 = omega * omega;
-            J[j++] = 0.4 * sf2 / sN * tauMx / (1.0 + omega2 * tauMx * tauMx);
+            J[j++] = spectralDensity(sf2, omega, tauMx);
         }
         return J;
     }

--- a/ringnmr/src/main/java/org/comdnmr/modelfree/models/MFModelSolidState.java
+++ b/ringnmr/src/main/java/org/comdnmr/modelfree/models/MFModelSolidState.java
@@ -1,0 +1,26 @@
+package org.comdnmr.modelfree.models;
+
+public class MFModelSolidState extends MFModelIso1 {
+
+    public MFModelSolidState(boolean fitTau, double targetTau, double tauFraction,
+            boolean includeEx) {
+        super(fitTau, targetTau, tauFraction, includeEx);
+    }
+
+    public MFModelSolidState(double targetTau) { super(targetTau); }
+
+    public MFModelSolidState() { super(); }
+
+    // Spectral density commonly used for solid state (i.e. with no global tumbling term).
+    // See Eq 14 of J. Phys. Chem. B 2017, 121, 25, 6117–6130
+    @Override
+    public double spectralDensity(double s2, double omega, double tau) {
+        double oneMinusS2 = 1.0 - s2;
+        return super.spectralDensity(oneMinusS2, omega, tau);
+    }
+
+    @Override
+    public String getName() {
+        return "modelSS";
+    }
+}


### PR DESCRIPTION
Created new `ModelFreeSolidState` class. Inhertis from `ModelFreeIso1`.
Basically the same except that the spectral density computed involves S2 being replaced with (1 - S2).
