### PR TITLE
Functionality for simulating solid state R1ρ rates

### DIFF
--- a/ringnmr-gui/src/main/java/org/comdnmr/gui/PyController.java
+++ b/ringnmr-gui/src/main/java/org/comdnmr/gui/PyController.java
@@ -1253,24 +1253,17 @@ public class PyController implements Initializable {
             xTickTextField.setText("2.0");
             yTickTextField.setText("5.0");
         } else if (simControls instanceof SSR1RhoControls) {
-            xychart.setNames("R1ρ Solid State", "ω1 (rad s⁻¹)", "R1ρ (s⁻¹)", "20");
-            xychart.setBounds(
-                2.0 * Math.PI * 1.0e3,
-                40.0 * Math.PI * 1.0e3,
-                0.0,
-                1000.0,
-                2.0 * Math.PI * 5.0e3,
-                100.0
-            );
-            xLowerBoundTextField.setText("3.0");
-            xUpperBoundTextField.setText("40.0");
+            xychart.setNames("R1ρ Solid State", "ν1 (kHz)", "log₁₀[R1ρ (s⁻¹)]", "20");
+            xychart.setBounds(1.0, 50.0, -1.0, 5.0, 5.0, 1.0);
+            xLowerBoundTextField.setText("1.0");
+            xUpperBoundTextField.setText("50.0");
+            xTickTextField.setText("5.0");
+            yLowerBoundTextField.setText("-1.0");
+            yUpperBoundTextField.setText("5.0");
+            yTickTextField.setText("1.0");
             if (hasExperimentSet()) {
                 // TODO
             }
-            yLowerBoundTextField.setText("0.0");
-            yUpperBoundTextField.setText("1000.0");
-            xTickTextField.setText("5.0");
-            yTickTextField.setText("100.0");
         }
     }
 

--- a/ringnmr-gui/src/main/java/org/comdnmr/gui/SSR1RhoControls.java
+++ b/ringnmr-gui/src/main/java/org/comdnmr/gui/SSR1RhoControls.java
@@ -26,17 +26,15 @@ public class SSR1RhoControls extends EquationControls {
     static PyController controller = PyController.mainController;
     static final double OMEGA_1_MIN = 2.0 * Math.PI * 2.0e3;  // ν1 (min) = 2kHz
     static final double OMEGA_1_MAX = 2.0 * Math.PI * 40.0e3;  // ν1 (max) = 40kHz
-    static final double OMEGA_R_MIN = 2.0 * Math.PI * 2.0e3;  // νR (min) = 2kHz
-    static final double OMEGA_R_MAX = 2.0 * Math.PI * 40.0e3;  // νR (max) = 40kHz
+    static final double NU_R_MIN = 1.0;  // νR (min) = 1kHz
+    static final double NU_R_MAX = 50.0;  // νR (max) = 50kHz
 
     // TODO this is largely parroting the relevant code in R1RhoControls...
     // Should this be generalized?
     enum PARS implements ParControls {
-        TAUC("τc", 0.0, 1.0e-4, 1.0e-6, 1.0e-5, 10),
-        S2("S²", 0.0, 1.0, 0.01, 0.3285, 3),
-        // TODO currently, ω1 is fixed as the independent variable
-        // OMEGA1("ω1", OMEGA_1_MIN, OMEGA_1_MAX, 1.0e3, 2.0 * Math.PI * 10.0e3, 2),
-        OMEGAR("ωR", OMEGA_R_MIN, OMEGA_R_MAX, 1.0e3, 2.0 * Math.PI * 10.0e3, 2);
+        TAUC("log₁₀(τc)", -8.0, -1.0, 1.0, -4.174, 3),
+        S2("S²", 0.0, 1.0, 0.1, 0.3285, 4),
+        OMEGAR("νR (kHz)", NU_R_MIN, NU_R_MAX, 5.0, 10.0, 2);
 
         String name;
         Slider slider;
@@ -278,13 +276,13 @@ public class SSR1RhoControls extends EquationControls {
         double[][] pars;
         switch (equationName) {
             case "CSA":
-                double tauc = PARS.TAUC.getValue();
+                double tauc = Math.pow(10.0, PARS.TAUC.getValue());
                 double s2 = PARS.S2.getValue();
-                double omegaR = PARS.OMEGAR.getValue();
+                double nuRkHz = PARS.OMEGAR.getValue();
                 pars = new double[2][2];
                 pars[0][0] = tauc;
                 pars[0][1] = s2;
-                pars[1][0] = omegaR;
+                pars[1][0] = nuRkHz;
                 break;
             default:
                 pars = null;

--- a/ringnmr/src/main/java/org/comdnmr/eqnfit/PlotEquation.java
+++ b/ringnmr/src/main/java/org/comdnmr/eqnfit/PlotEquation.java
@@ -75,24 +75,21 @@ public class PlotEquation {
     }
 
     public double calculate(double[] simPars, double[] xValue) {
+        double val;
         if (expType.startsWith("model")) {
-            return calculateSpectralDensity(xValue, simPars);
+            val = calculateSpectralDensity(xValue, simPars);
         } else {
             EquationType equationType = ResidueFitter.getEquationType(expType, name);
             int[][] map = equationType.makeMap(1);
-            return equationType.calculate(simPars, map[0], xValue, 0);
+            val = equationType.calculate(simPars, map[0], xValue, 0);
+            if (expType.equals("ssr1rho")) {
+                val = Math.log10(val);
+            }
         }
+        return val;
     }
 
-    public double calculate(double[] xValue) {
-        if (expType.startsWith("model")) {
-            return calculateSpectralDensity(xValue);
-        } else {
-            EquationType equationType = ResidueFitter.getEquationType(expType, name);
-            int[][] map = equationType.makeMap(1);
-            return equationType.calculate(pars, map[0], xValue, 0);
-        }
-    }
+    public double calculate(double[] xValue) { return calculate(pars, xValue); }
 
     private double calculateSpectralDensity(double[] xValue) {
         return calculateSpectralDensity(xValue, pars);

--- a/ringnmr/src/main/java/org/comdnmr/eqnfit/SSR1RhoEquation.java
+++ b/ringnmr/src/main/java/org/comdnmr/eqnfit/SSR1RhoEquation.java
@@ -22,8 +22,8 @@
  */
 package org.comdnmr.eqnfit;
 
-import java.util.Arrays;
 import org.comdnmr.modelfree.RelaxEquations;
+import org.comdnmr.util.CoMDPreferences;
 
 /**
  *
@@ -34,18 +34,25 @@ public enum SSR1RhoEquation implements EquationType {
     CSA("SSR1RhoCSA", 0, "tauc", "s2") {
 
         @Override
+        // nu1 and nuR are both provided in kHz
         public double calculate(double[] par, int[] map, double[] x, int idNum) {
-            double tauc = par[map[0]];
-            double s2 = par[map[1]];
-            double omega1 = x[0];
-            double omegaR = x[1];
+            // FIXME: During simulations, getting map = [1, 0]... not sure why
+            // expected tauc = par[map[0]] and s2 = par[map[1]]
+            double tauc = par[map[1]];
+            double s2 = par[map[0]];
+            double nu1kHz = x[0];
+            double nuRkHz = x[1];
+            double omega1 = 2.0e3 * Math.PI * nu1kHz;
+            double omegaR = 2.0e3 * Math.PI * nuRkHz;
 
             // TODO: Check that this line is facilitated in the GUI, in order
             // to vary SIGMA.
             // N.B. Δσ = 3/2 δ
             RelaxEquations.setSigma("C", (3.0 / 2.0) * -36.77e-6);
-            var relaxEquations = new RelaxEquations(400.0e6, "H", "C");
-            return relaxEquations.r1RhoCSA(omegaR, omega1, tauc, s2);
+            double b0 = 1.0e6 * CoMDPreferences.getRefField();
+            RelaxEquations relaxEquations = new RelaxEquations(b0, "H", "C");
+            double r1rho = relaxEquations.r1RhoCSA(omegaR, omega1, tauc, s2);
+            return r1rho;
         }
 
         @Override
@@ -151,5 +158,13 @@ public enum SSR1RhoEquation implements EquationType {
     @Override
     public int getNGroupPars() {
         return nGroupPars;
+    }
+
+    public double getMinX() {
+        return 1.0;
+    }
+
+    public double getMaxX() {
+        return 50.0;
     }
 }


### PR DESCRIPTION
This is still a working progress. Going forward the following will need to be addressed:

* Y-axis scale: Currently, the y-axis is logarithmic. Would be useful to toggle between linear and logarithmic.
* Tweaking the CSA: The system under consideration is currently hard-coded to be 13C with δ=-36.77ppm (and η=0 by necessity). Should provide support to (a) change the nucleus, and (b) adjust δ (N.B. δ = 2/3 Δσ). There is already a drop-down for the nucelus, so this should be easy to include. I'm guessing the best way to allow for the CSA to be edited is by including a parameter in `CoMDPreferences`?
* Support for multiple curves, for example plots for different values of τc, analogous to Figure 2(c) in Eric and Ann's paper.
* Support for different independent variables. Currently hard-coded to ν1 (i.e dispersion curves).
* Support for heatmaps.